### PR TITLE
Creates default Contributing and Conduct references

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,1 @@
+EDGI's Code of Conduct is available here: [EDGI Code of Conduct](https://github.com/edgi-govdata-archiving/overview/blob/master/CONDUCT.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Contributing Guidelines
+
+We love improvements to our tools! EDGI has general [guidelines for contributing][edgi-contributing] and a [code of conduct][edgi-conduct] for all of our organizational repos.
+
+<!-- Links -->
+[edgi-conduct]: https://github.com/edgi-govdata-archiving/overview/blob/master/CONDUCT.md
+[edgi-contributing]: https://github.com/edgi-govdata-archiving/overview/blob/master/CONTRIBUTING.md

--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+[![Code of Conduct](https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-blue.svg?style=flat)](https://github.com/edgi-govdata-archiving/overview/blob/master/CONDUCT.md)
+
+# Configuration across the EDGI Github Organization
+This repo contains configurations that apply by default across the organization's repos, if not specified in the individual repo. Learn more in the [Github documentation](https://help.github.com/en/github/building-a-strong-community/setting-up-your-project-for-healthy-contributions).


### PR DESCRIPTION
I noticed it was possible to have these apply org-wide, so added them here. Any reason we shouldn't?