### PR TITLE
Add global stalebot configuration

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,19 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 180
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 14
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - never-stale
+  - security
+  - bug
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed in seven days if no further activity
+  occurs. If it should not be closed, please comment! Thank you for your
+  contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
We have a lot of stalebot configuration files -- one in each repo -- and it's tough to keep them all in sync. Stalebot (via Probot) now supports extending the configuration from another repo, so we can make all our different configuration files point to this new, centralized file. That way we only need to update this one.

See edgi-govdata-archiving/overview#235 for more discussion.