### PR TITLE
Update funding link to new donation URL

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,4 +1,4 @@
-custom: 'https://www.flipcause.com/widget/MTEyNjc5'
+custom: 'https://envirodatagov.org/donate/'
 
 ## Also supported, but we don't currently use them:
 # github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]


### PR DESCRIPTION
We moved off Flipcause last year, but this link apparently never got updated!